### PR TITLE
ci(#209): bump node from 18 to 22 for playwright 1.62 compatibility

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install Playwright
         working-directory: ./playwright

--- a/.github/workflows/production-e2e-tests.yml
+++ b/.github/workflows/production-e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install Playwright
         working-directory: ./playwright


### PR DESCRIPTION
Playwright 1.62.0 dropped Node.js 18 support (its `engines` requirement changed from `node >=18` to `node >=20`), which makes the "Build and Test" check fail on Dependabot PR #206. Node 18 has been EOL since April 2025 and Node 20 since April 2026, so this bumps both workflows to the current LTS, Node 22:

- `.github/workflows/ci-cd.yml`
- `.github/workflows/production-e2e-tests.yml`

All 80 Playwright E2E tests pass locally via `./test-before-commit.sh`.

After merging, comment `@dependabot rebase` on #206 to rebase it onto the updated `master`.

Fixes #209