### PR TITLE
fix(#204): skip Google Analytics for automation-driven browsers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ Jekyll 4.4 static site for https://aistomin.com (personal site: home, about, blo
 
 `start.sh` wipes `_site`, `.jekyll-cache`, `.jekyll-metadata` and rebuilds the image, so there is no stale-cache class of bug — if the site looks wrong, it is the source.
 
+Everything above except `cleanup_branches.sh` needs the Docker daemon up — check it with `docker info` before you rely on it, and ask the user to start Docker Desktop if it is down.
+
 Non-Docker alternative: `bundle install && bundle exec jekyll serve`.
 
 Playwright commands (from `playwright/`):
@@ -171,6 +173,18 @@ implementation is not approval to commit, approving the commit is not approval t
 
 5. **Propose the changes — do not make them yet.** Describe what will change, in which files, and
    which Playwright specs need to follow. Edit files only after an explicit go.
+
+   Check the Docker daemon as part of the proposal, not later:
+
+   ```bash
+   docker info --format '{{.ServerVersion}}'
+   ```
+
+   `./test-before-commit.sh` runs the site in Docker, so it fails outright when the daemon is down.
+   Only the user can start Docker Desktop — you cannot. Finding that out *after* the implementation
+   is finished wastes a round trip, so say it up front, in the same message as the proposal: either
+   "Docker is running, tests will work" or "Docker is not running — please start Docker Desktop
+   before you approve this". Never wait until the tests fail to mention it.
 
    Once implemented: run `./test-before-commit.sh` and report the real result.
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,12 +31,21 @@
 
     {% if jekyll.environment == "production" %}
         <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-8LBQ2S5TJD"></script>
+        <!-- Loaded only for real visitors. Automation-driven browsers (Playwright,
+             Selenium, …) set navigator.webdriver, so our e2e suites — including the
+             daily one that runs against the live site — generate no pseudotraffic. -->
         <script>
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'G-8LBQ2S5TJD');
+            if (!navigator.webdriver) {
+                var gaScript = document.createElement('script');
+                gaScript.async = true;
+                gaScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-8LBQ2S5TJD';
+                document.head.appendChild(gaScript);
+
+                window.dataLayer = window.dataLayer || [];
+                window.gtag = function () { dataLayer.push(arguments); };
+                gtag('js', new Date());
+                gtag('config', 'G-8LBQ2S5TJD');
+            }
         </script>
     {% endif %}
 </head>

--- a/playwright/tests/analytics.spec.js
+++ b/playwright/tests/analytics.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+
+// Every host gtag.js talks to when it reports a page view.
+const ANALYTICS_HOST = /googletagmanager\.com|google-analytics\.com|analytics\.google\.com/;
+
+// One regular page and one post, so both the `default` and the `post` layout are covered.
+const PAGES = ['/', '/2025/11/19/goethe-c1-exam'];
+
+test.describe('Google Analytics', () => {
+  // The tag is wrapped in an `if (!navigator.webdriver)` guard in _layouts/default.html.
+  // Playwright sets that flag, so these runs must never reach Google Analytics.
+  //
+  // Note this is only meaningful where the tag actually ships: CI (which builds with
+  // JEKYLL_ENV=production) and the daily run against https://aistomin.com. A local
+  // ./start.sh builds in development mode, where the snippet is absent altogether.
+  for (const path of PAGES) {
+    test(`should not send any data to Google Analytics from an automated browser on ${path}`, async ({ page }) => {
+      const analyticsRequests = [];
+      page.on('request', (request) => {
+        if (ANALYTICS_HOST.test(request.url())) {
+          analyticsRequests.push(request.url());
+        }
+      });
+
+      await page.goto(path);
+
+      // networkidle rather than domcontentloaded: gtag.js is injected asynchronously,
+      // so it has to be given the chance to fire before we assert that it did not.
+      await page.waitForLoadState('networkidle');
+
+      expect(analyticsRequests).toEqual([]);
+      expect(await page.evaluate(() => typeof window.dataLayer)).toBe('undefined');
+    });
+  }
+});


### PR DESCRIPTION
## Problem

The e2e suites polluted Google Analytics with pseudotraffic from two sources:

- `ci-cd.yml` builds with `JEKYLL_ENV: production` before serving the site locally and running Playwright against it, so every push and PR to `master` was recorded as real page views (on hostname `0.0.0.0`).
- `production-e2e-tests.yml` runs the same suite against https://aistomin.com every night, so those hits landed on the real hostname and were indistinguishable from genuine visitors.

## Proposal

Load `gtag.js` only when `navigator.webdriver` is false, which Playwright, Selenium and other automation drivers all set. This is a single change in `_layouts/default.html` that covers both sources — no workflow or config changes needed.

The `<script async src=…>` tag becomes a runtime `createElement` injection, because a static tag cannot be made conditional. `gtag` becomes `window.gtag = function …` rather than a `function` declaration, since a declaration inside an `if` block is not reliably reachable outside it.

## Verification

Verified against a real production-mode build (`JEKYLL_ENV=production`), since a local `./start.sh` builds in development mode where the snippet is absent entirely and any such test would pass vacuously:

| Check | Result |
|---|---|
| Production build serves the guarded tag | `if (!navigator.webdriver)` present in served HTML |
| New `analytics.spec.js` against that build | 2 passed — zero analytics requests, `dataLayer` undefined |
| GA still fires for a real visitor (`navigator.webdriver` spoofed to false, request aborted in-browser) | `gtag.js` requested, `dataLayer` initialized — no hit ever sent to Google |
| Full `./test-before-commit.sh` | 82 passed (80 before, +2 new) |

The third row is the important one: it rules out the failure mode where the guard silently kills analytics for everyone.

## Notes

- This does not remove pseudotraffic **already** recorded in GA, and does not stop non-webdriver bots. Both need Google Analytics console work (internal traffic filters / data deletion), which is outside this repository.
- Also adds the Docker-daemon check to the ticket workflow in `CLAUDE.md` — a small working-agreement adjustment made along the way.

Closes #204