### PR TITLE
build(#207): make dependabot use conventional commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,20 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "build"
+      include: "scope"
   - package-ecosystem: npm
     directory: /playwright
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "build"
+      include: "scope"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "build"
+      include: "scope"


### PR DESCRIPTION
## Problem

Dependabot authored most commits here with its default `Bump <dep> from <x> to <y>`
format, which is not a Conventional Commit.

## Fix

Adds `commit-message` with `prefix: "build"` and `include: "scope"` to every entry
under `updates:` in `.github/dependabot.yml` (bundler, npm, github-actions), so bumps
render as:

```
build(deps): bump <dependency> from <old-version> to <new-version>
build(deps-dev): bump <dev-dependency> from <old-version> to <new-version>
```

## Verification

- `./test-before-commit.sh` passes (82/82 Playwright tests) — config-only change, no
  rendered output is affected, so no spec changes were needed.
- YAML parsed and asserted that all three `updates:` entries carry the block.

## Notes

- Not retroactive. There are currently no open Dependabot PRs, so nothing needs
  `@dependabot recreate`; the first real proof lands with the next weekly run.
  `@playwright/test` is the only devDependency, so it will be the first to exercise
  the `deps-dev` scope.
- CI enforcement of commit-message format is out of scope per the ticket.

Closes #207