### PR TITLE
fix(#218): remove date of birth from certificates page

### DIFF
--- a/certificates.markdown
+++ b/certificates.markdown
@@ -25,7 +25,6 @@ description: "Professional certifications and achievements of Andrej Istomin, in
                     <p><strong>Issued:</strong> Munich, 03.09.2025</p>
                     <p><strong>Certificate No:</strong> 2048-AC1A-0002450866</p>
                     <p><strong>Institution:</strong> Goethe-Institut</p>
-                    <p><strong>My Date of Birth (for verification):</strong> 17.05.1985</p>
                     <p><strong>Verify:</strong> <a href="https://www.goethe.de/verify" target="_blank" rel="noopener noreferrer">www.goethe.de/verify</a></p>
                 </div>
             </div>

--- a/playwright/tests/certificates.spec.js
+++ b/playwright/tests/certificates.spec.js
@@ -70,8 +70,10 @@ test.describe('Certificates Page', () => {
     await expect(metadata).toContainText('Issued: Munich, 03.09.2025');
     await expect(metadata).toContainText('Certificate No: 2048-AC1A-0002450866');
     await expect(metadata).toContainText('Institution: Goethe-Institut');
-    await expect(metadata).toContainText('My Date of Birth (for verification): 17.05.1985');
     await expect(metadata).toContainText('Verify:');
+
+    // The date of birth must never be published (see issue #218)
+    await expect(page.locator('body')).not.toContainText('Date of Birth');
   });
 
   test('should have working external links', async ({ page }) => {


### PR DESCRIPTION
## What

Removes the "My Date of Birth (for verification)" line from the certificates page. The DOB is now available on request only.

## Why

Name + full DOB is a classic identity-theft pair and was published together with the certificate number — exactly the credential set goethe.de/verify asks for.

The Playwright spec now asserts that "Date of Birth" appears nowhere on the page. The assertion deliberately checks the label, not the literal date, so the DOB does not reappear in the public spec file.

Git history is intentionally left untouched (accepted risk — moderate PII, not a credential; a history rewrite is not worth the disruption).

All 82 e2e tests pass via `./test-before-commit.sh`.

Closes #218