### PR TITLE
fix(#217): make analytics cookieless and gate disqus behind a click

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,6 +34,10 @@
         <!-- Loaded only for real visitors. Automation-driven browsers (Playwright,
              Selenium, …) set navigator.webdriver, so our e2e suites — including the
              daily one that runs against the live site — generate no pseudotraffic. -->
+        <!-- Consent Mode v2 with all storage denied keeps gtag.js cookieless:
+             no cookies means no §25 TDDDG consent requirement and no banner.
+             Analytics falls back to anonymous pings, so GA figures are modeled
+             estimates rather than cookie-deduplicated counts. -->
         <script>
             if (!navigator.webdriver) {
                 var gaScript = document.createElement('script');
@@ -43,6 +47,12 @@
 
                 window.dataLayer = window.dataLayer || [];
                 window.gtag = function () { dataLayer.push(arguments); };
+                gtag('consent', 'default', {
+                    'ad_storage': 'denied',
+                    'analytics_storage': 'denied',
+                    'ad_user_data': 'denied',
+                    'ad_personalization': 'denied'
+                });
                 gtag('js', new Date());
                 gtag('config', 'G-8LBQ2S5TJD');
             }

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -39,18 +39,26 @@ layout: default
   {% if page.comments %}
   <div class="comments-section">
     <div id="disqus_thread"></div>
+    <!-- Disqus sets tracking cookies, so it must not load until the visitor
+         asks for it ("two-click" pattern) — the click is the consent. -->
+    <button id="load-comments" class="load-comments" type="button">💬 Load comments</button>
+    <p class="comments-privacy-note">
+      Comments are provided by Disqus, a third-party service, and load only when you request them.
+    </p>
     <script>
       var disqus_config = function () {
         this.page.url = '{{ site.url }}{{ page.url }}';
         this.page.identifier = '{{ page.id | default: page.url }}';
       };
-      (function () {
+      document.getElementById('load-comments').addEventListener('click', function () {
         var d = document,
           s = d.createElement('script');
         s.src = 'https://https-aistomin-com.disqus.com/embed.js';
         s.setAttribute('data-timestamp', +new Date());
         (d.head || d.body).appendChild(s);
-      })();
+        this.style.display = 'none';
+        d.querySelector('.comments-privacy-note').style.display = 'none';
+      });
     </script>
     <noscript>
       Please enable JavaScript to view the

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -217,6 +217,31 @@ a:hover {
     border-bottom: 1px solid #e1e5e9;
 }
 
+.load-comments {
+    display: block;
+    margin: 1.5rem auto 0.5rem;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 500;
+    color: #fff;
+    background-color: #2c3e50;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.load-comments:hover {
+    background-color: #555;
+}
+
+.comments-privacy-note {
+    text-align: center;
+    font-size: 0.85rem;
+    color: #666;
+    margin-bottom: 1.5rem;
+}
+
 /* Page styles */
 .page-header {
     text-align: center;

--- a/playwright/tests/goethe-c1-exam.spec.js
+++ b/playwright/tests/goethe-c1-exam.spec.js
@@ -204,16 +204,32 @@ test.describe('Goethe C1 Exam Blog Post', () => {
     await expect(page.locator('.page-title')).toContainText('What\'s Next? (Part III)');
   });
 
-  test('should display comments section if enabled', async ({ page }) => {
+  test('should load Disqus comments only after the visitor requests them', async ({ page }) => {
+    const disqusRequests = [];
+    page.on('request', (request) => {
+      if (/disqus\.com/.test(request.url())) {
+        disqusRequests.push(request.url());
+      }
+    });
+
     await page.goto('/2025/11/19/goethe-c1-exam', { waitUntil: 'domcontentloaded' });
-    
-    // Check that Disqus comments section exists
-    const commentsSection = page.locator('.comments-section');
-    await expect(commentsSection).toBeVisible();
-    
-    // Check for Disqus thread div
-    const disqusThread = page.locator('#disqus_thread');
-    await expect(disqusThread).toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    // Disqus sets tracking cookies, so nothing from it may load before the
+    // visitor clicks the button ("two-click" pattern, see issue #217)
+    expect(disqusRequests).toEqual([]);
+
+    // The section shows a load button and a privacy note instead of the thread
+    await expect(page.locator('.comments-section')).toBeVisible();
+    const loadButton = page.locator('#load-comments');
+    await expect(loadButton).toBeVisible();
+    await expect(page.locator('.comments-privacy-note')).toBeVisible();
+
+    // The click is the consent: Disqus loads and the button disappears
+    const embedRequest = page.waitForRequest(/disqus\.com/);
+    await loadButton.click();
+    await embedRequest;
+    await expect(loadButton).toBeHidden();
   });
 });
 

--- a/playwright/tests/goethe-c1-preparations.spec.js
+++ b/playwright/tests/goethe-c1-preparations.spec.js
@@ -220,16 +220,32 @@ test.describe('Goethe C1 Preparations Blog Post', () => {
     await expect(page.locator('.page-title')).toHaveText('Essays About Everything and Nothing');
   });
 
-  test('should display comments section if enabled', async ({ page }) => {
+  test('should load Disqus comments only after the visitor requests them', async ({ page }) => {
+    const disqusRequests = [];
+    page.on('request', (request) => {
+      if (/disqus\.com/.test(request.url())) {
+        disqusRequests.push(request.url());
+      }
+    });
+
     await page.goto('/2025/11/25/goethe-c1-preparations', { waitUntil: 'domcontentloaded' });
-    
-    // Check that Disqus comments section exists
-    const commentsSection = page.locator('.comments-section');
-    await expect(commentsSection).toBeVisible();
-    
-    // Check for Disqus thread div
-    const disqusThread = page.locator('#disqus_thread');
-    await expect(disqusThread).toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    // Disqus sets tracking cookies, so nothing from it may load before the
+    // visitor clicks the button ("two-click" pattern, see issue #217)
+    expect(disqusRequests).toEqual([]);
+
+    // The section shows a load button and a privacy note instead of the thread
+    await expect(page.locator('.comments-section')).toBeVisible();
+    const loadButton = page.locator('#load-comments');
+    await expect(loadButton).toBeVisible();
+    await expect(page.locator('.comments-privacy-note')).toBeVisible();
+
+    // The click is the consent: Disqus loads and the button disappears
+    const embedRequest = page.waitForRequest(/disqus\.com/);
+    await loadButton.click();
+    await embedRequest;
+    await expect(loadButton).toBeHidden();
   });
 });
 

--- a/playwright/tests/goethe-c1-whats-next.spec.js
+++ b/playwright/tests/goethe-c1-whats-next.spec.js
@@ -144,15 +144,31 @@ test.describe('Goethe C1 What\'s Next Blog Post', () => {
     await expect(page.locator('.page-title')).toHaveText('Essays About Everything and Nothing');
   });
 
-  test('should display comments section if enabled', async ({ page }) => {
+  test('should load Disqus comments only after the visitor requests them', async ({ page }) => {
+    const disqusRequests = [];
+    page.on('request', (request) => {
+      if (/disqus\.com/.test(request.url())) {
+        disqusRequests.push(request.url());
+      }
+    });
+
     await page.goto('/2025/12/07/goethe-c1-whats-next', { waitUntil: 'domcontentloaded' });
-    
-    // Check that Disqus comments section exists
-    const commentsSection = page.locator('.comments-section');
-    await expect(commentsSection).toBeVisible();
-    
-    // Check for Disqus thread div
-    const disqusThread = page.locator('#disqus_thread');
-    await expect(disqusThread).toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    // Disqus sets tracking cookies, so nothing from it may load before the
+    // visitor clicks the button ("two-click" pattern, see issue #217)
+    expect(disqusRequests).toEqual([]);
+
+    // The section shows a load button and a privacy note instead of the thread
+    await expect(page.locator('.comments-section')).toBeVisible();
+    const loadButton = page.locator('#load-comments');
+    await expect(loadButton).toBeVisible();
+    await expect(page.locator('.comments-privacy-note')).toBeVisible();
+
+    // The click is the consent: Disqus loads and the button disappears
+    const embedRequest = page.waitForRequest(/disqus\.com/);
+    await loadButton.click();
+    await embedRequest;
+    await expect(loadButton).toBeHidden();
   });
 });


### PR DESCRIPTION
## What

- **Google Analytics**: gtag.js now runs with Consent Mode v2 and all storage denied by default. No cookies are set, GA falls back to anonymous cookieless pings, so §25 TDDDG consent (the cookie banner) is not triggered. The `navigator.webdriver` guard from #204 stays in place. Note: GA users/sessions become modeled estimates instead of cookie-deduplicated counts.
- **Disqus**: no longer auto-loads on posts with comments. A "Load comments" button plus a short third-party note replaces it; clicking fetches the original embed ("two-click" pattern — the click is the consent). Zero bytes from disqus.com until then, which also makes post pages lighter.
- **Specs**: the three post specs' comments tests are now behavioral — they assert no disqus.com requests on page load, the button and note are visible, and that clicking fires the embed request and hides the button.

## Compliance stance (the "conscious decision" the ticket asks to document)

This site is deliberately private and non-commercial: no Impressum and no privacy policy page are added, and no consent banner — instead the site avoids *needing* one by not storing anything on the visitor.

All 82 e2e tests pass via `./test-before-commit.sh`.

Closes #217