### PR TITLE
fix(#215): take the footer year from the visitor's clock

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -80,8 +80,19 @@
 
     <footer class="site-footer">
         <div class="footer-content">
-            <p>&copy; 2025–{{ 'now' | date: "%Y" }} {{ site.title }}. All rights reserved.</p>
+            <p>&copy; 2025–<span id="footer-year">{{ 'now' | date: "%Y" }}</span> {{ site.title }}. All rights reserved.</p>
         </div>
     </footer>
+    <!-- The year above is rendered at build time, so a deployed page would keep
+         showing a stale year from January 1st until the next redeploy — refresh it
+         from the visitor's clock. -->
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        var year = document.getElementById('footer-year');
+        if (year) {
+          year.textContent = new Date().getFullYear();
+        }
+      });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

The footer year was rendered at build time (`{{ 'now' | date: "%Y" }}`), while
`playwright/tests/navigation.spec.js` asserts the runtime year
(`new Date().getFullYear()`). From January 1st the deployed footer would show the
previous year until something triggered a redeploy, so the daily production e2e
workflow would fail every day until then.

## Change

`_layouts/default.html` wraps the year in `<span id="footer-year">` and overwrites
it from the visitor's clock on `DOMContentLoaded`. The Liquid build year stays as
the initial text, so visitors without JavaScript and crawlers still see a valid
year instead of a dangling dash. Same inline-script idiom as the post date in
`_layouts/post.html`.

No Playwright changes: the existing footer test already asserts the runtime year,
and now the page agrees with it.

## Verification

- `./test-before-commit.sh` — 82 passed.
- The green suite alone doesn't prove the fix (build year and today's year are both
  2026), so it was checked with a faked browser clock: the served HTML carries the
  build year `2026`, and with the clock set to 2029 the footer renders
  `© 2025–2029 Andrej Istomin. All rights reserved.` — the January-1st case from the
  ticket.

Closes #215