### PR TITLE
build(#216): build the dev image from ruby 3.2 instead of a dead jekyll image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,11 @@ _site/
 # Dependencies
 .bundle/
 vendor/
+playwright/node_modules/
+
+# Playwright output
+playwright/test-results/
+playwright/playwright-report/
 
 # OS generated files
 .DS_Store

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,10 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "build"
+      include: "scope"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,16 +41,39 @@ Jekyll 4.4 static site for https://aistomin.com (personal site: home, about, blo
 ## Commands
 
 ```bash
-./start.sh                # rebuild + run dev server in Docker at http://localhost:4000 (-d for background)
+./start.sh                # rebuild image + run dev server with livereload in Docker at http://localhost:4000 (-d for background)
 ./stop.sh                 # docker compose down
 ./run-e2e-tests.sh        # run Playwright against an already-running server
 ./test-before-commit.sh   # full cycle: start -d, wait for :4000, run e2e, stop. Run this before committing.
 ./cleanup_branches.sh     # delete local branches whose remote is gone
 ```
 
-`start.sh` wipes `_site`, `.jekyll-cache`, `.jekyll-metadata` and rebuilds the image, so there is no stale-cache class of bug — if the site looks wrong, it is the source.
+`start.sh` wipes `_site`, `.jekyll-cache`, `.jekyll-metadata` and rebuilds the image
+(`docker compose up --build`, layer-cached so it costs about a second when nothing changed), so
+there is no stale-cache class of bug — if the site looks wrong, it is the source.
 
-Everything above except `cleanup_branches.sh` needs the Docker daemon up — check it with `docker info` before you rely on it, and ask the user to start Docker Desktop if it is down.
+The image comes from the checked-in `Dockerfile`: `ruby:3.2-slim-bookworm`, deliberately the same
+Ruby minor as `ruby-version` in `.github/workflows/ci-cd.yml`, so the site previewed locally is
+built by the same toolchain as production. Move the two together when Ruby is bumped — Dependabot's
+`docker` ecosystem is what will tell you it is time.
+
+Gems are installed into the image at build time (into `/usr/local/bundle`, outside the bind mount),
+so a `Gemfile` change needs a rebuild — which `start.sh` does anyway. `BUNDLE_FROZEN=true` in the
+image stops the container from silently rewriting the committed `Gemfile.lock`; a `Gemfile` edit
+without a matching lock update fails the build instead. Update gems deliberately:
+
+```bash
+docker compose run --rm -e BUNDLE_FROZEN=false jekyll bundle update
+```
+
+Jekyll serves with `--livereload --force_polling` (port 35729), so a saved edit refreshes the
+browser by itself. Polling is required because file-change events do not cross the macOS bind mount
+reliably. Livereload injects a `livereload.js` script tag into every served page, so the local DOM
+differs from production by that one tag — CI runs the same specs against a livereload-free
+production build, which is where fidelity is guaranteed.
+
+Everything above except `cleanup_branches.sh` needs the Docker daemon up — check it with
+`docker info` before you rely on it, and ask the user to start Docker Desktop if it is down.
 
 Non-Docker alternative: `bundle install && bundle exec jekyll serve`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,25 @@
-FROM --platform=linux/arm64 jekyll/jekyll:latest
+# Local dev image. Keep the Ruby minor in step with ci-cd.yml's ruby-version so
+# the site previewed here is built by the same toolchain that builds production.
+FROM ruby:3.2-slim-bookworm
+
+# ffi and eventmachine (which livereload runs on) ship no precompiled Linux
+# gems, so the image needs a compiler.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Gems install into GEM_HOME (/usr/local/bundle), outside the workdir, so the
+# bind mount cannot shadow them. Frozen: the container must never rewrite the
+# committed Gemfile.lock — see CLAUDE.md for the deliberate-update command.
+ENV BUNDLE_FROZEN=true
 
 WORKDIR /srv/jekyll
 
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
 EXPOSE 4000 35729
 
-CMD bundle install && bundle exec jekyll serve --host 0.0.0.0 --port 4000 --livereload --force_polling
+CMD ["bundle", "exec", "jekyll", "serve", \
+     "--host", "0.0.0.0", "--port", "4000", \
+     "--livereload", "--force_polling"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,10 +18,14 @@ GEM
       logger
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
+    google-protobuf (4.33.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.33.0-arm64-darwin)
       bigdecimal
       rake (>= 13)
@@ -89,9 +93,14 @@ GEM
     rexml (3.4.4)
     rouge (4.6.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.97.2)
+    sass-embedded (1.97.2-aarch64-linux-gnu)
       google-protobuf (~> 4.31)
-      rake (>= 13)
+    sass-embedded (1.97.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -102,9 +111,9 @@ GEM
     webrick (1.9.1)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-24
   x86_64-linux
-  x86_64-linux-musl
 
 DEPENDENCIES
   base64 (~> 0.1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
 services:
   jekyll:
-    image: jekyll/jekyll:latest
+    build: .
     ports:
       - '4000:4000'
-      - '35729:35729'
+      - '35729:35729' # livereload
     volumes:
       - .:/srv/jekyll
-    command: jekyll serve --force_polling

--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@ docker compose down -v
 rm -rf _site .jekyll-cache .jekyll-metadata
 
 if [ "$1" = "-d" ] || [ "$1" = "--background" ]; then
-    docker compose up -d
+    docker compose up -d --build
 else
-    docker compose up
+    docker compose up --build
 fi


### PR DESCRIPTION
## Problem

`docker-compose.yml` pinned `jekyll/jekyll:latest` with no `build:` directive, so the
checked-in `Dockerfile` was dead code. Local dev ran a three-year-old image — Ruby 3.1.1
musl, amd64 under emulation on Apple Silicon — that reinstalled 45 gems on every start,
and livereload was never enabled despite port 35729 being mapped.

## Change

- `Dockerfile` rebased on `ruby:3.2-slim-bookworm`, the same Ruby minor as `ci-cd.yml`'s
  `ruby-version`, with `build-essential` for `ffi`/`eventmachine`, gems installed at build
  time into `/usr/local/bundle`, and `BUNDLE_FROZEN=true` so the container can never
  rewrite the committed lock. No platform pin — builds native.
- `docker-compose.yml` builds it; serve flags live only in the `Dockerfile` `CMD`.
- `start.sh` uses `up --build`, making the existing `CLAUDE.md` claim true.
- `Gemfile.lock`: `+aarch64-linux`, `-x86_64-linux-musl` (a fossil the old image left).
  `BUNDLED WITH` deliberately unchanged.
- `.dockerignore`: exclude `playwright/node_modules` and Playwright output, now that the
  repo is a build context.
- `.github/dependabot.yml`: watch the base image so it cannot rot unnoticed.
- `CLAUDE.md`: document the toolchain alignment, the gem-update escape hatch, and the
  livereload script-tag divergence.

CI stays on `ruby/setup-ruby` — `Gemfile.lock` is the contract, and both sides are now
Ruby 3.2 glibc.

## Verification

`./test-before-commit.sh` — 82 passed. Livereload confirmed running (`LiveReload address:
http://0.0.0.0:35729`) with `livereload.js` injected into pages; the suite passes with it.
Startup after a `--no-cache` rebuild: ready in 2s, versus ~30s of `bundle install` per
start before.

Note: the very first run, the one including the initial from-scratch build, tripped
`test-before-commit.sh`'s 65s wait budget once. It has not reproduced across three
subsequent full cycles including a `--no-cache` rebuild, and it has no established root
cause. The retry budget was left as-is rather than raised to mask it.

Closes #216