### PR TITLE
ci(#219): scope deploy permissions to the deploy job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,8 +10,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: 'pages'
@@ -21,6 +19,12 @@ jobs:
   test:
     name: Build and Test
     runs-on: ubuntu-latest
+    # This job runs third-party code (npm ci, browser downloads) on every pull
+    # request, so it gets no deploy credentials — only what configure-pages needs
+    # to read the Pages base path.
+    permissions:
+      contents: read
+      pages: read
     env:
       JEKYLL_ENV: production
     steps:
@@ -78,6 +82,9 @@ jobs:
     if: github.ref == 'refs/heads/master'
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Problem

Workflow-level `permissions` granted `pages: write` and `id-token: write`, so the `test`
job — which runs `npm ci` and downloads browsers on every pull request — carried deploy
credentials it never uses.

## Change

Workflow level drops to `contents: read`. The `deploy` job gets `pages: write` +
`id-token: write` (no `contents`, it has no checkout). The `test` job gets
`contents: read` + `pages: read` — one deviation from the ticket's wording, because
`actions/configure-pages` reads the Pages API to produce the `base_path` used by
`jekyll build --baseurl`, and fails with the `pages` scope at `none`. Read access is not a
deploy credential, so the concern in the ticket is addressed.

## Verification

Workflow YAML parsed and asserted: top `contents: read`, test `contents: read, pages: read`,
deploy `pages: write, id-token: write`. `./test-before-commit.sh` — 82 passed (it cannot
validate a workflow; the real check is this PR's own run). The `deploy` job only executes on
master, so its block was kept identical to GitHub's official Pages example.

Closes #219