### PR TITLE
ci(#220): split the pages concurrency group off the test job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,14 +11,16 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: 'pages'
-  cancel-in-progress: false
-
 jobs:
   test:
     name: Build and Test
     runs-on: ubuntu-latest
+    # Superseded runs of the same ref are pointless — they test a commit that has
+    # already been replaced. Cancelling here is safe: job-level concurrency cannot
+    # reach the deploy job, so a Pages deploy in flight is never interrupted.
+    concurrency:
+      group: test-${{ github.ref }}
+      cancel-in-progress: true
     # This job runs third-party code (npm ci, browser downloads) on every pull
     # request, so it gets no deploy credentials — only what configure-pages needs
     # to read the Pages base path.
@@ -82,6 +84,11 @@ jobs:
     if: github.ref == 'refs/heads/master'
     needs: test
     runs-on: ubuntu-latest
+    # GitHub Pages allows one deployment at a time, and a deploy must never be
+    # cancelled midway — so deploys queue, and only against other deploys.
+    concurrency:
+      group: 'pages'
+      cancel-in-progress: false
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
Stops PR test runs and master Pages deploys from blocking each other.

## What was wrong

`concurrency: { group: pages, cancel-in-progress: false }` sat at the **workflow** level, so every run of every kind contended for a single slot. A PR test run queued behind a master deploy, and a master deploy queued behind a PR test run — despite the two sharing nothing.

## The fix

- **`deploy` gets the `pages` group.** That is where the real constraint lives: GitHub Pages allows one deployment at a time, and `cancel-in-progress: false` keeps a deploy from being killed midway. Deploys now serialise only against other deploys.
- **`test` gets its own per-ref group**, `test-${{ github.ref }}` with `cancel-in-progress: true`. Push again to the same branch and the older run is cancelled instead of finishing a test of a commit you have already replaced. `github.ref` differs per PR, so different PRs never collide.

Cancelling in the test job cannot interrupt a deploy: job-level concurrency only ever cancels its own job. If a master run is already inside `Deploy to GitHub Pages`, a new push cancels the (already finished) test job and nothing else, and the new deploy queues under the separate `pages` group. That distinction is exactly what the workflow-level group got wrong — the same setting there would have killed deploys too.

Both groups are commented in place so the reasoning survives the next edit.

## Testing

`./test-before-commit.sh` passes — 82/82 Playwright tests green. To be clear about what that is worth: it proves nothing about this change, only that nothing was broken incidentally. `test-before-commit.sh` never reads `.github/workflows/`.

This PR's own run exercises the new `test` group. **The `deploy` group cannot be observed until this is on master** — no PR run reaches that job, since it is gated on `github.ref == 'refs/heads/master'`. Worth a glance at the first master deploy after merge.

Closes #220