### PR TITLE
refactor(#223): render the post header server-side

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,11 +3,14 @@ layout: default
 ---
 
 <style>
-  .post-header-wrapper {
-    text-align: center;
-    padding: 0.5rem 0;
-    border-bottom: 1px solid #e1e5e9;
-    margin-bottom: 1rem;
+  /* Centering comes from .page-header; only the spacing below the image is ours. */
+  .post-header-logo {
+    margin-bottom: 0.5rem;
+  }
+
+  .post-header-logo img {
+    height: 3rem;
+    width: auto;
   }
 
   .post-date-in-header {
@@ -18,18 +21,22 @@ layout: default
   }
 </style>
 
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    const pageHeader = document.querySelector('.page-header');
-    if (pageHeader) {
-      const dateDiv = document.createElement('div');
-      dateDiv.className = 'post-date-in-header';
-      dateDiv.innerHTML =
-        '<time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>';
-      pageHeader.appendChild(dateDiv);
-    }
-  });
-</script>
+<!-- The header is layout-owned and carries nothing post-specific: the image comes
+     from the post's `header_image` front matter, and a post without one gets just
+     the title and the date. Rendered with Liquid rather than injected on
+     DOMContentLoaded, so crawlers and non-JS readers see the date and there is no
+     layout shift. -->
+<div class="page-header">
+  {% if page.header_image %}
+  <div class="post-header-logo">
+    <img src="{{ page.header_image }}" alt="{{ page.header_image_alt }}">
+  </div>
+  {% endif %}
+  <h1 class="page-title">{{ page.title }}</h1>
+  <div class="post-date-in-header">
+    <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+  </div>
+</div>
 
 {{ content }}
 

--- a/_posts/2025-11-19-goethe-c1-exam.markdown
+++ b/_posts/2025-11-19-goethe-c1-exam.markdown
@@ -5,6 +5,8 @@ date: 2025-11-19 12:00:00 +0200
 excerpt: A couple of months have already passed since I got my Goethe-Zertifikat C1. It was a goal that took me several years to achieve. It was not super difficult, but it cost me a significant amount of time and mental effort. Now, with a cool head, I can look back on those events and try to put my experience on paper.
 keywords: Goethe-Zertifikat C1, Goethe C1 exam, German language exam, C1 exam experience, Goethe-Institut Munich, German certification, language learning, C1 speaking test, C1 writing test, modular Goethe exam
 image: /assets/images/goethe-institut-muenchen.jpg
+header_image: /assets/images/goethe-institut.png
+header_image_alt: Goethe Institut
 comments: true
 ---
 
@@ -47,13 +49,6 @@ comments: true
         text-align: center;
     }
 </style>
-
-<div class="page-header">
-    <div style="text-align: center; margin-bottom: 0.5rem;">
-        <img src="/assets/images/goethe-institut.png" alt="Goethe Institut" class="goethe-logo">
-    </div>
-    <h1 class="page-title">Goethe-Zertifikat C1 — The Exam (Part I)</h1>
-</div>
 
 <div class="page-content">
     <p>A couple of months have already passed since I got my <a href="https://www.goethe.de/ins/de/en/prf/prf/gzc1.html" target="_blank" rel="noopener noreferrer">Goethe-Zertifikat C1</a>. It was a goal that took me several years to achieve. It was not super difficult, but it cost me a significant amount of time and mental effort. Now, with a cool head, I can look back on those events and try to put my experience on paper.</p>

--- a/_posts/2025-11-25-goethe-c1-preparations.markdown
+++ b/_posts/2025-11-25-goethe-c1-preparations.markdown
@@ -5,15 +5,10 @@ date: 2025-11-25 22:00:00 +0100
 excerpt: In the second part of my Goethe-Zertifikat C1 trilogy I'd like to share my approach to preparing for this exam and reflect a little on what I think I did right and what I definitely did wrong. I'm not a linguistic expert, so don't expect any professional advice here — the internet is full of people who provide that. I just dare to hope that you'll find something interesting and maybe even helpful in this long post. Grab your coffee and let's get started!
 keywords: Goethe-Zertifikat C1, C1 exam preparation, German language learning, language learning journey, Lingster Academy, German grammar courses, CEFR levels, exam preparation strategies, German literature, language immersion, language learning resources
 image: /assets/images/goethe-c1-preparations.jpg
+header_image: /assets/images/goethe-institut.png
+header_image_alt: Goethe Institut
 comments: true
 ---
-
-<div class="page-header">
-    <div style="text-align: center; margin-bottom: 0.5rem;">
-        <img src="/assets/images/goethe-institut.png" alt="Goethe Institut" class="goethe-logo">
-    </div>
-    <h1 class="page-title">Goethe-Zertifikat C1 — Preparations (Part II)</h1>
-</div>
 
 <div class="page-content">
     <p>

--- a/_posts/2025-12-07-goethe-c1-whats-next.markdown
+++ b/_posts/2025-12-07-goethe-c1-whats-next.markdown
@@ -5,15 +5,10 @@ date: 2025-12-07 08:00:00 +0100
 excerpt: "This is the third and final part of my Goethe-Zertifikat C1 trilogy. In this part I want to share my thoughts regarding the C2 certification: whether I am going to do it or not and, if yes, what concrete steps I need to take in order to achieve it. So, let me make God laugh and share my plans with you — and with Him."
 keywords: Goethe C2, German language learning, C1 to C2 journey, German certification, language learning strategy, advanced German, Goethe-Zertifikat preparation, German grammar mastery, German language exam, C2 level planning, German study plan, learning German effectively
 image: /assets/images/goethe-c1-whats-next.jpg
+header_image: /assets/images/goethe-institut.png
+header_image_alt: Goethe Institut
 comments: true
 ---
-
-<div class="page-header">
-    <div style="text-align: center; margin-bottom: 0.5rem;">
-        <img src="/assets/images/goethe-institut.png" alt="Goethe Institut" class="goethe-logo">
-    </div>
-    <h1 class="page-title">Goethe-Zertifikat C1 — What's Next? (Part III)</h1>
-</div>
 
 <div class="page-content">
     <div class="epigraph">

--- a/playwright/tests/post-header.spec.js
+++ b/playwright/tests/post-header.spec.js
@@ -1,0 +1,49 @@
+const { test, expect } = require('@playwright/test');
+
+// The header used to be assembled on DOMContentLoaded, which the rest of the suite
+// cannot distinguish from server-rendered markup — a scripted header passes those
+// assertions just as well. These run with JavaScript switched off, the way a crawler
+// or a non-JS reader sees the page, so they fail if the header ever goes back to
+// being injected at runtime.
+test.use({ javaScriptEnabled: false });
+
+const POSTS = [
+  {
+    path: '/2025/11/19/goethe-c1-exam',
+    title: 'Goethe-Zertifikat C1 — The Exam (Part I)',
+    date: 'November 19, 2025',
+    datetime: '2025-11-19',
+  },
+  {
+    path: '/2025/11/25/goethe-c1-preparations',
+    title: 'Goethe-Zertifikat C1 — Preparations (Part II)',
+    date: 'November 25, 2025',
+    datetime: '2025-11-25',
+  },
+  {
+    path: '/2025/12/07/goethe-c1-whats-next',
+    title: "Goethe-Zertifikat C1 — What's Next? (Part III)",
+    date: 'December 7, 2025',
+    datetime: '2025-12-07',
+  },
+];
+
+test.describe('Post header without JavaScript', () => {
+  for (const post of POSTS) {
+    test(`should render title, date and logo on ${post.path}`, async ({ page }) => {
+      await page.goto(post.path, { waitUntil: 'domcontentloaded' });
+
+      const header = page.locator('.page-header');
+      await expect(header.locator('.page-title')).toHaveText(post.title);
+
+      const time = header.locator('.post-date-in-header time');
+      await expect(time).toHaveText(post.date);
+      // The offset varies per post, so anchor on the calendar date only.
+      await expect(time).toHaveAttribute('datetime', new RegExp(`^${post.datetime}T`));
+
+      const logo = header.locator('.post-header-logo img');
+      await expect(logo).toHaveAttribute('src', '/assets/images/goethe-institut.png');
+      await expect(logo).toHaveAttribute('alt', 'Goethe Institut');
+    });
+  }
+});


### PR DESCRIPTION
Replaces the client-side date injection with a server-rendered, layout-owned post header.

## What was wrong

`_layouts/post.html` appended the date to `.page-header` on `DOMContentLoaded`. The date was invisible to crawlers and non-JS readers, and appeared a frame after paint as layout shift.

## The fix

The header moves into `post.html` and is rendered with Liquid. Critically, it carries **nothing post-specific**:

```liquid
<div class="page-header">
  {% if page.header_image %}
  <div class="post-header-logo">
    <img src="{{ page.header_image }}" alt="{{ page.header_image_alt }}">
  </div>
  {% endif %}
  <h1 class="page-title">{{ page.title }}</h1>
  <div class="post-date-in-header">
    <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
  </div>
</div>
```

The logo comes from a new `header_image` front-matter field (`header_image_alt` beside it), so a future post on an unrelated topic supplies its own image — or none, in which case it gets just the title and the date. Previously every post hand-wrote the same header markup, which meant a new post could silently omit the date entirely.

The three existing posts drop their `.page-header` block and gain:

```yaml
header_image: /assets/images/goethe-institut.png
header_image_alt: Goethe Institut
```

Two tidy-ups that belong with this change:

- `.post-header-wrapper` is deleted — unreferenced anywhere in the repo, and a duplicate of `.page-header`s rules.
- The logo class is the neutral `.post-header-logo`, not the existing `.goethe-logo`. That class stays in `main.css` for `certificates.markdown`, where the Goethe name is accurate; a layout-owned header should not carry it.

Rendering is byte-equivalent for JS-enabled visitors — same classes, same text, same order — which is why the other 85 tests needed no edits.

## Tests

New `playwright/tests/post-header.spec.js` asserts title, date text, `datetime` attribute and logo for all three posts, with **`javaScriptEnabled: false`**.

That flag is the point. Every existing date spec passes both before and after this change, because the script produced identical DOM — **nothing in the suite could distinguish a scripted header from a rendered one**, so nothing would catch a regression to client-side injection.

I verified the new spec actually discriminates rather than assuming it: stashing the source changes, keeping the spec, and rebuilding produced 3 failures, all at `.post-date-in-header time` — which never appears without JavaScript. Restoring gives 88/88.

`./test-before-commit.sh` passes: **88/88** (85 before, +3 new).

Closes #223