### PR TITLE
fix(#239): label the feed link by format-neutral name

### DIFF
--- a/_includes/follow-links.html
+++ b/_includes/follow-links.html
@@ -24,7 +24,7 @@
             <path d="M15.725 0l-1.72 1.277 6.39 8.588 1.716-1.277L15.725 0zm-3.94 3.418l-1.369 1.644 8.225 6.85 1.369-1.644-8.225-6.85zm-3.15 4.465l-.905 1.94 9.702 4.517.904-1.94-9.701-4.517zm-1.85 4.86l-.44 2.093 10.473 2.201.44-2.092-10.473-2.203zM1.89 15.47V24h19.19v-8.53h-2.133v6.397H4.021v-6.396H1.89zm4.265 2.133v2.13h10.66v-2.13H6.154Z"/>
         </svg>
     </a>
-    <a href="/feed.xml" target="_blank" rel="noopener noreferrer" aria-label="RSS Feed">
+    <a href="/feed.xml" target="_blank" rel="noopener noreferrer" aria-label="Feed">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path d="M4 4a16 16 0 0 1 16 16h-3A13 13 0 0 0 4 7V4zm0 7a9 9 0 0 1 9 9h-3a6 6 0 0 0-6-6v-3zm.5 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"/>
         </svg>

--- a/playwright/tests/about.spec.js
+++ b/playwright/tests/about.spec.js
@@ -83,10 +83,10 @@ test.describe('About Page', () => {
     await expect(stackoverflowLink).toHaveAttribute('href', 'http://stackoverflow.com/users/1842599');
     await expect(stackoverflowLink).toHaveAttribute('aria-label', 'Stack Overflow');
     
-    // Test RSS Feed link
-    const rssLink = socialLinks.nth(5);
-    await expect(rssLink).toHaveAttribute('href', '/feed.xml');
-    await expect(rssLink).toHaveAttribute('aria-label', 'RSS Feed');
+    // Test feed link
+    const feedLink = socialLinks.nth(5);
+    await expect(feedLink).toHaveAttribute('href', '/feed.xml');
+    await expect(feedLink).toHaveAttribute('aria-label', 'Feed');
   });
 
   test('should have working external links', async ({ page }) => {

--- a/playwright/tests/home.spec.js
+++ b/playwright/tests/home.spec.js
@@ -82,10 +82,10 @@ test.describe('Home Page', () => {
     await expect(stackoverflowLink).toHaveAttribute('href', 'http://stackoverflow.com/users/1842599');
     await expect(stackoverflowLink).toHaveAttribute('aria-label', 'Stack Overflow');
     
-    // Test RSS Feed link
-    const rssLink = socialLinks.nth(5);
-    await expect(rssLink).toHaveAttribute('href', '/feed.xml');
-    await expect(rssLink).toHaveAttribute('aria-label', 'RSS Feed');
+    // Test feed link
+    const feedLink = socialLinks.nth(5);
+    await expect(feedLink).toHaveAttribute('href', '/feed.xml');
+    await expect(feedLink).toHaveAttribute('aria-label', 'Feed');
   });
 
   test('should navigate from Home to About and back to Home', async ({ page }) => {


### PR DESCRIPTION
Renames the social block feed link's `aria-label` from "RSS Feed" to "Feed".

## What was wrong

`_includes/follow-links.html` announced "RSS Feed" to screen-reader users for a link to `/feed.xml`, which jekyll-feed generates as an **Atom 1.0** document. This is the same inaccuracy #222 avoided by declaring `type="application/atom+xml"` in the head — the social block simply had not caught up.

Sighted users see only the icon, so nothing changes visually.

## The fix

- `_includes/follow-links.html` — `aria-label="RSS Feed"` → `aria-label="Feed"`. Accurate whichever format the generator emits, and it reads in parallel with the other five labels in the block, which are all short destination nouns (`LinkedIn`, `Xing`, `Upwork`, `GitHub`, `Stack Overflow`).
- `playwright/tests/home.spec.js` and `playwright/tests/about.spec.js` — the asserted string, plus the `rssLink` variable and the `// Test RSS Feed link` comment. Renaming those rides along deliberately: fixing the label while leaving test code that calls an Atom feed "RSS" three lines away would just relocate the inaccuracy.

The SVG icon is untouched — it is the conventional feed glyph regardless of format.

## Tests

`./test-before-commit.sh` passes: **88/88**.

The two updated assertions are a genuine check rather than a rubber stamp — changing the include without the specs, or the specs without the include, fails the suite. The include and its tests are pinned together.

Closes #239