### PR TITLE
chore(#227): delete the unreferenced svg favicon

### DIFF
--- a/assets/images/favicon.svg
+++ b/assets/images/favicon.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" fill="#2c3e50"/>
-  <text x="50" y="70" font-family="Arial, sans-serif" font-size="48" font-weight="700" fill="#fff" text-anchor="middle">AI</text>
-</svg>
-

--- a/playwright/tests/head-meta.spec.js
+++ b/playwright/tests/head-meta.spec.js
@@ -55,5 +55,26 @@ test.describe('Head meta tags', () => {
       // og:logo is not part of the Open Graph protocol.
       await expect(page.locator('meta[property="og:logo"]')).toHaveCount(0);
     });
+
+    test(`should declare exactly one favicon on ${path}`, async ({ page }) => {
+      await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+      const icon = page.locator('link[rel="icon"]');
+      await expect(icon).toHaveCount(1);
+      await expect(icon).toHaveAttribute('href', '/favicon.ico');
+      await expect(icon).toHaveAttribute('type', 'image/x-icon');
+    });
   }
+
+  test('should serve the declared favicon', async ({ request }) => {
+    const response = await request.get('/favicon.ico');
+    expect(response.status()).toBe(200);
+  });
+
+  test('should not publish an unreferenced svg favicon', async ({ request }) => {
+    // The .ico carries this exact design, so a second unlinked copy is dead
+    // weight that still gets published. Keep it deleted.
+    const response = await request.get('/assets/images/favicon.svg');
+    expect(response.status()).toBe(404);
+  });
 });


### PR DESCRIPTION
## What

Deletes `assets/images/favicon.svg`. `_layouts/default.html` is unchanged — `/favicon.ico` stays the single declared icon.

## Why delete rather than reference

The git history answers this. The SVG *was* the linked favicon until `857d562` replaced that link with `/favicon.ico`; the file was deliberately unlinked, then left behind and published unused ever since. Both files render the same design — dark slate square, white bold "AI" — so nothing visible changes.

It was also the weaker of the two on its own merits: the SVG draws the letters as `<text font-family="Arial">`, so it renders differently on a machine without Arial, while the rasterised `.ico` looks the same everywhere.

## Tests

Favicon coverage added to `head-meta.spec.js`:

- on every nav page and one post: exactly one `link[rel="icon"]`, `href="/favicon.ico"`, `type="image/x-icon"`
- `/favicon.ico` serves 200
- `/assets/images/favicon.svg` returns 404 — this is the assertion that pins the deletion, so an unlinked copy cannot quietly reappear

`./test-before-commit.sh`: **114 passed** (107 before + 7 new).

## Noticed, not fixed

`favicon.ico` is a 32×32 PNG with an `.ico` extension, declared as `type="image/x-icon"` — three different answers for one file. Browsers sniff the content so the live site is correct, but it is worth a separate ticket.

Closes #227