### PR TITLE
chore(#226): delete unused comments css and label comments

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}</title>
-    
-    <!-- SEO Meta Tags -->
+
     <meta name="description" content="{{ page.excerpt | default: page.description | default: site.description | strip_html | truncate: 160 }}">
     {% if page.keywords %}<meta name="keywords" content="{{ page.keywords }}">{% endif %}
     <meta name="author" content="{{ site.author | default: site.title }}">
@@ -14,7 +13,6 @@
          readers and browsers discover it without being handed the URL. -->
     {% feed_meta %}
 
-    <!-- Open Graph / Facebook -->
     <meta property="og:type" content="{% if page.layout == 'post' %}article{% else %}website{% endif %}">
     <!-- Same expression as the canonical link above on purpose: two spellings of
          the same page URL is what makes crawlers treat them as two pages. -->
@@ -23,8 +21,6 @@
     <meta property="og:description" content="{{ page.excerpt | default: page.description | default: site.description | strip_html | truncate: 160 }}">
     {% if page.image %}<meta property="og:image" content="{{ site.url }}{{ page.image }}">{% endif %}
 
-    <!-- Twitter -->
-    <!-- Twitter cards are read from name=, not the property= that Open Graph uses. -->
     <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
     <meta name="twitter:url" content="{{ site.url }}{{ page.url | replace: 'index.html', '' }}">
     <meta name="twitter:title" content="{% if page.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}">
@@ -35,7 +31,6 @@
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}?v={{ site.time | date: '%s' }}">
 
     {% if jekyll.environment == "production" %}
-        <!-- Google tag (gtag.js) -->
         <!-- Loaded only for real visitors. Automation-driven browsers (Playwright,
              Selenium, …) set navigator.webdriver, so our e2e suites — including the
              daily one that runs against the live site — generate no pseudotraffic. -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,6 @@ layout: default
 ---
 
 <style>
-  /* Centering comes from .page-header; only the spacing below the image is ours. */
   .post-header-logo {
     margin-bottom: 0.5rem;
   }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,4 +1,3 @@
-/* Reset and base styles */
 * {
     margin: 0;
     padding: 0;
@@ -32,7 +31,6 @@ a:hover {
     text-decoration-color: #666;
 }
 
-/* Header and Navigation */
 .site-header {
     background: #fff;
     border-bottom: 1px solid #e1e5e9;
@@ -86,7 +84,6 @@ a:hover {
     padding-bottom: 2px;
 }
 
-/* Main content */
 .main-content {
     min-height: calc(100vh - 140px);
     padding: 0.5rem 0 3rem 0;
@@ -98,7 +95,6 @@ a:hover {
     padding: 0 2rem;
 }
 
-/* Homepage styles */
 .hero {
     text-align: center;
     padding: 2rem 0;
@@ -188,33 +184,14 @@ a:hover {
     transition: fill 0.3s ease;
 }
 
-/* Post layout tweaks */
 .post-social {
     max-width: 800px;
     margin: 4rem auto;
 }
 
-/* Comments spacer */
-.comments-spacer {
-    height: 4rem;
-    max-width: 800px;
-    margin: 0 auto;
-    border-top: 1px solid #e1e5e9;
-}
-
-/* Comments section */
 .comments-section {
     max-width: 800px;
     margin: 0 auto;
-}
-
-.comments-title {
-    font-size: 1.5rem;
-    font-weight: 400;
-    color: #2c3e50;
-    margin-bottom: 1.5rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 1px solid #e1e5e9;
 }
 
 .load-comments {
@@ -242,7 +219,6 @@ a:hover {
     margin-bottom: 1.5rem;
 }
 
-/* Page styles */
 .page-header {
     text-align: center;
     padding: 0.5rem 0;
@@ -250,7 +226,6 @@ a:hover {
     margin-bottom: 1rem;
 }
 
-/* Epigraph styles */
 .epigraph {
     text-align: center;
     margin: 2rem auto;
@@ -331,7 +306,6 @@ a:hover {
     font-style: italic;
 }
 
-/* Blog posts */
 .blog-posts {
     margin-top: 2rem;
 }
@@ -388,7 +362,6 @@ a:hover {
     border-bottom-color: #2c3e50;
 }
 
-/* Certificates */
 .goethe-logo {
     height: 3rem;
     width: auto;
@@ -454,7 +427,6 @@ a:hover {
     }
 }
 
-/* Footer */
 .site-footer {
     background: #f8f9fa;
     border-top: 1px solid #e1e5e9;
@@ -470,7 +442,6 @@ a:hover {
     color: #666;
 }
 
-/* Responsive design */
 @media (max-width: 768px) {
     .nav-container {
         flex-direction: column;


### PR DESCRIPTION
## Problem

`.comments-spacer` and `.comments-title` in `assets/css/main.css` matched no markup — no layout,
include, post body or spec referenced them, and `.comments-title` could never apply anyway since
Disqus renders inside its own iframe.

The ticket also listed `.post-header-wrapper`; #223 already removed it when the post header moved to
server-side rendering, so there was nothing left to delete there.

## Changes

Deletions only, across three files:

- the two dead CSS rules;
- the eleven section labels in `main.css` (`/* Footer */`, `/* Certificates */`, …) and four label
  comments in `default.html` (`<!-- SEO Meta Tags -->`, `<!-- Open Graph / Facebook -->`,
  `<!-- Twitter -->`, `<!-- Google tag (gtag.js) -->`) — each only restated the code beneath it;
- two notes explaining mechanics rather than decisions: `name=` vs `property=` for Twitter cards, and
  `.page-header` centering in `post.html`.

Comments that record a decision stay: Consent Mode v2 / §25 TDDDG cookieless analytics, the
`navigator.webdriver` gate keeping e2e traffic out of GA, Disqus two-click consent, `og:url` and the
`/about.html` nav link both matching the canonical URL (#224), server-side post header rendering for
crawlers and non-JS readers (#223), `feed_meta` discoverability, and the footer year refresh.

## Verification

`./test-before-commit.sh` — 115/115 Playwright specs pass. Comments have no rendering effect and the
diff is deletions only.

Closes #226
