### PR TITLE
chore(#228): remove the scaffold placeholder email from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 title: Andrej Istomin
-email: your-email@example.com
 description: >-
   Software Engineer, Musician & Wandering Philosopher
 


### PR DESCRIPTION
## Problem

`_config.yml` carried `email: your-email@example.com` from the Jekyll scaffold.

## Changes

Removed the key. Nothing consumed it:

- no layout, include or page referenced `site.email`;
- `grep -rl` over the built `_site/` found the placeholder in zero files, so it was never published;
- jekyll-feed reads `site.author` (unset here), not `site.email` — which is why `feed.xml` has no
  `<author>` block, and why `default.html`'s author meta falls back to `site.title`;
- jekyll-sitemap does not use it, and there is no `mailto:` anywhere on the site.

A real contact address is a Version 1.2 decision. Rather than leave a bare `email:` key nothing
reads, it gets wired up — as `author: {name, email}` or a footer `mailto:` — when something actually
renders it.

## Verification

`./test-before-commit.sh` — 115/115 Playwright specs pass. The rebuilt `feed.xml` is unchanged in
shape: same `title` and `subtitle`, still no `<author>` block.

Closes #228
