### PR TITLE
refactor(#229): collapse duplicated photo rules and head expressions

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,30 +1,36 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    {% capture meta_title %}{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}{% endcapture -%}
+    {%- capture meta_description %}{{ page.excerpt | default: page.description | default: site.description | strip_html | truncate: 160 }}{% endcapture -%}
+    {%- comment -%}
+      page_path is the one spelling of the URL that canonical, og:url and twitter:url
+      all share: two spellings make crawlers treat them as two competing pages.
+    {%- endcomment -%}
+    {%- assign page_path = page.url | replace: 'index.html', '' -%}
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}</title>
+    <title>{{ meta_title }}</title>
 
-    <meta name="description" content="{{ page.excerpt | default: page.description | default: site.description | strip_html | truncate: 160 }}">
+    <meta name="description" content="{{ meta_description }}">
     {% if page.keywords %}<meta name="keywords" content="{{ page.keywords }}">{% endif %}
     <meta name="author" content="{{ site.author | default: site.title }}">
-    {% if site.url %}<link rel="canonical" href="{{ site.url }}{{ page.url | replace: 'index.html', '' }}">{% endif %}
+    {% if site.url %}<link rel="canonical" href="{{ site.url }}{{ page_path }}">{% endif %}
     <!-- jekyll-feed generates an Atom 1.0 feed at /feed.xml; this is what lets
          readers and browsers discover it without being handed the URL. -->
     {% feed_meta %}
 
     <meta property="og:type" content="{% if page.layout == 'post' %}article{% else %}website{% endif %}">
-    <!-- Same expression as the canonical link above on purpose: two spellings of
-         the same page URL is what makes crawlers treat them as two pages. -->
-    <meta property="og:url" content="{{ site.url }}{{ page.url | replace: 'index.html', '' }}">
-    <meta property="og:title" content="{% if page.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}">
-    <meta property="og:description" content="{{ page.excerpt | default: page.description | default: site.description | strip_html | truncate: 160 }}">
+    <meta property="og:url" content="{{ site.url }}{{ page_path }}">
+    <meta property="og:title" content="{{ meta_title }}">
+    <meta property="og:description" content="{{ meta_description }}">
     {% if page.image %}<meta property="og:image" content="{{ site.url }}{{ page.image }}">{% endif %}
 
     <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
-    <meta name="twitter:url" content="{{ site.url }}{{ page.url | replace: 'index.html', '' }}">
-    <meta name="twitter:title" content="{% if page.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}">
-    <meta name="twitter:description" content="{{ page.excerpt | default: page.description | default: site.description | strip_html | truncate: 160 }}">
+    <meta name="twitter:url" content="{{ site.url }}{{ page_path }}">
+    <meta name="twitter:title" content="{{ meta_title }}">
+    <meta name="twitter:description" content="{{ meta_description }}">
     {% if page.image %}<meta name="twitter:image" content="{{ site.url }}{{ page.image }}">{% endif %}
     
     <link rel="icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">

--- a/about.markdown
+++ b/about.markdown
@@ -9,7 +9,7 @@ description: "Learn about Andrej Istomin — a software engineer from Bishkek no
 </div>
 
 <div class="page-content">
-    <img src="/assets/images/me_young.jpg" alt="Andrej in younger years" class="about-photo" onerror="this.style.display='none'">
+    <img src="/assets/images/me_young.jpg" alt="Andrej in younger years" class="page-photo page-photo-portrait" onerror="this.style.display='none'">
     
     <p>I grew up in Bishkek, Kyrgyz SSR, in a world that was rapidly changing. The Soviet Union collapsed when I was six. Maybe that's why I've always been drawn to understanding how systems work—and what happens when they don't. At a specialized physics-mathematical lyceum, I learned to think in patterns and abstractions. But it was my father who introduced me to Deep Purple, and that changed everything. Around the same time, I discovered Dostoevsky. Both taught me that beneath technical precision, there's always something deeper—emotion, meaning, chaos.</p>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -115,15 +115,19 @@ a:hover {
     font-weight: 300;
 }
 
-.hero-photo {
+.page-photo {
     width: 200px;
     height: 200px;
     border-radius: 50%;
     object-fit: cover;
-    margin: 2rem auto;
+    margin: 0 auto 2rem auto;
     display: block;
     border: 4px solid #f8f9fa;
     box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+}
+
+.page-photo-portrait {
+    object-position: center 30%;
 }
 
 .hero-description {
@@ -271,30 +275,6 @@ a:hover {
 
 .page-content li {
     margin-bottom: 0.5rem;
-}
-
-.about-photo {
-    width: 200px;
-    height: 200px;
-    border-radius: 50%;
-    object-fit: cover;
-    object-position: center 30%;
-    margin: 0 auto 2rem auto;
-    display: block;
-    border: 4px solid #f8f9fa;
-    box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-}
-
-.blog-photo {
-    width: 200px;
-    height: 200px;
-    border-radius: 50%;
-    object-fit: cover;
-    object-position: center center;
-    margin: 0 auto 2rem auto;
-    display: block;
-    border: 4px solid #f8f9fa;
-    box-shadow: 0 4px 20px rgba(0,0,0,0.1);
 }
 
 .blog-description {

--- a/blog.markdown
+++ b/blog.markdown
@@ -10,7 +10,7 @@ image: /assets/images/blog-og.jpg
 </div>
 
 <div class="page-content">
-    <img src="/assets/images/blog.jpg" alt="Andrej Istomin" class="blog-photo" onerror="this.style.display='none'">
+    <img src="/assets/images/blog.jpg" alt="Andrej Istomin" class="page-photo" onerror="this.style.display='none'">
     <p class="blog-description">
     This is where I put longer pieces and shorter notes: What I’m building, what I’m studying, and what I’m thinking about. The topics include work, hobbies, side projects, and whatever else holds my attention. There’s no single theme and no fixed schedule — just writing when something feels worth saying.
     </p>

--- a/certificates.markdown
+++ b/certificates.markdown
@@ -9,7 +9,7 @@ description: "Professional certifications and achievements of Andrej Istomin, in
 </div>
 
 <div class="page-content">
-    <img src="/assets/images/me-and-guitar.png" alt="Andrej with guitar" class="about-photo" onerror="this.style.display='none'">
+    <img src="/assets/images/me-and-guitar.png" alt="Andrej with guitar" class="page-photo page-photo-portrait" onerror="this.style.display='none'">
     
     <p>Learning never stops. Here's what I've earned along the way:</p>
     

--- a/index.markdown
+++ b/index.markdown
@@ -9,7 +9,7 @@ image: /assets/images/home-og.jpg
     <h1>Andrej Istomin</h1>
     <p class="subtitle">Software Engineer, Musician & Wandering Philosopher</p>
     
-    <img src="/assets/images/home.jpg" alt="Andrej Istomin" class="hero-photo" onerror="this.style.display='none'">
+    <img src="/assets/images/home.jpg" alt="Andrej Istomin" class="page-photo" onerror="this.style.display='none'">
     
     <div class="hero-description">
         <p>

--- a/playwright/tests/about.spec.js
+++ b/playwright/tests/about.spec.js
@@ -23,7 +23,7 @@ test.describe('About Page', () => {
     await expect(title).toHaveText('Wandering Between Code, Chords and Schelling');
     
     // 2. Test picture exists
-    const photo = page.locator('.about-photo');
+    const photo = page.locator('.page-photo');
     await expect(photo).toBeVisible();
     await expect(photo).toHaveAttribute('src', '/assets/images/me_young.jpg');
     await expect(photo).toHaveAttribute('alt', 'Andrej in younger years');

--- a/playwright/tests/certificates.spec.js
+++ b/playwright/tests/certificates.spec.js
@@ -23,7 +23,7 @@ test.describe('Certificates Page', () => {
     await expect(title).toHaveText('Certificates & Professional Achievements');
 
     // 2. Test photo exists
-    const photo = page.locator('.about-photo');
+    const photo = page.locator('.page-photo');
     await expect(photo).toBeVisible();
     await expect(photo).toHaveAttribute('src', '/assets/images/me-and-guitar.png');
     await expect(photo).toHaveAttribute('alt', 'Andrej with guitar');

--- a/playwright/tests/home.spec.js
+++ b/playwright/tests/home.spec.js
@@ -27,7 +27,7 @@ test.describe('Home Page', () => {
     await expect(subheader).toHaveText('Software Engineer, Musician & Wandering Philosopher');
     
     // 3. Test picture exists
-    const photo = page.locator('.hero-photo');
+    const photo = page.locator('.page-photo');
     await expect(photo).toBeVisible();
     await expect(photo).toHaveAttribute('src', '/assets/images/home.jpg');
     await expect(photo).toHaveAttribute('alt', 'Andrej Istomin');


### PR DESCRIPTION
## Problem

The ticket listed four duplication smells. Two of them no longer exist — #223 already moved the post
`<h1>` into the layout and removed the `.page-header` redeclaration, so `post.html`'s remaining inline
rules (`.post-header-logo`, `.post-date-in-header`) are unique to it and no post body duplicates its
front-matter title. The other two were real, and one was bigger than reported.

## Changes

**Photo rules — three, not two.** `.hero-photo` on the homepage shared the same eight declarations as
`.about-photo` and `.blog-photo`. All three collapse into one `.page-photo`, plus a
`.page-photo-portrait` modifier for the only genuine difference: the `center 30%` crop on about and
certificates.

Two of the reported "differences" turned out not to be differences at all:

- `.blog-photo`'s `object-position: center center` is the CSS initial value;
- `.hero-photo`'s `margin: 2rem auto` was collapsed away by `.hero .subtitle`'s own `margin-bottom: 2rem`
  — measured in the browser, the homepage photo renders at `top: 268px` with or without it.

So a single margin renders all four images identically, with no contextual override needed.

**Head expressions.** `default.html` repeated the description fallback chain 3×, the page URL
expression 3× and the title expression 2× (`<title>` used a variant emitting a character-identical
string). Each is captured once now. The URL capture is the load-bearing one: `head-meta.spec.js`
asserts `canonical`, `og:url` and `twitter:url` are character-for-character equal, and three copies of
an expression is how that drifts.

`.about-photo` also stopped lying — it was in use on the certificates page.

## Verification

`./test-before-commit.sh` — 115/115 Playwright specs pass. Three spec locators followed the rename
(`home`, `about`, `certificates`).

Two extra checks, since this is a pure refactor:

- **Built output compared page by page against a pre-refactor snapshot.** Across all 9 generated HTML
  files the only differences are the intended ones — the photo classes, and the old
  "same expression on purpose" HTML comment replaced by a Liquid comment that ships nothing to the
  browser. Every `canonical`, `og:*`, `twitter:*`, `<title>` and description value is byte-identical.
- **Rendered geometry measured in Chromium before and after**: home `top: 268`, about/blog/certificates
  `top: 184`, all 200×200, `object-position: 50% 30%` preserved on about and certificates, same border,
  radius and shadow.

Closes #229
